### PR TITLE
REFACTOR : 수정적용

### DIFF
--- a/src/components/landing/FriendRecommendations.tsx
+++ b/src/components/landing/FriendRecommendations.tsx
@@ -1,4 +1,3 @@
-// 4
 import { useState, useEffect } from 'react';
 import supabase from '@/api/supabaseApi';
 

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -103,7 +103,7 @@ function SignupForm() {
     }
 
     const userId = data.user?.id;
-    const { data: profiles, error: profileError } = await supabase
+    const { error: profileError } = await supabase
       .from('profiles')
       .insert([
         { id: userId, nickname: formData.nickname, profile_image: null },


### PR DESCRIPTION
- [x] type은 컴포넌트 밖에서 선언
- [x] 이름이 좀 이상하네요. isSession(세션이니?) 라는 뜻으로 보이는데 isSession에 user.id가 있는 것이 이상합니다.
- [x] chatGPT 쓴 거 너무 티내지 맙시당. 회사에선 잘 지웁시다.

- [x]  해당 로직이 무슨 뜻인지 정확히 이해하고 넘어갑시다.
```javascript
 const { data: existingRooms, error } = await supabase 
   .from('chat_room') 
   .select('id') 
   .or( 
     `and(user1_id.eq.${userId},user2_id.eq.${selectedFriendId}),and(user1_id.eq.${selectedFriendId},user2_id.eq.${userId})` 
   ); 
```
- [x] 하나만 가져올 거라면 처음부터 배열이 아니라 하나만 가져오게 할 수 있습니다.
  🧐 single 을 적용했더니 아래와 같은 오류가 발생 했습니다 해서 or 식을 변경해 해결했습니다 이방법뿐일지,, 궁금하긴 합니다. 
<img width="652" alt="스크린샷 2024-08-09 오후 2 46 48" src="https://github.com/user-attachments/assets/01bf61e1-55fa-4778-9262-44cdc087eb4a">

- [x]  버튼 클릭 시 해당 채팅방으로 들어가거나, 채팅이 없으면 생성하는 버튼을 만들어 로직들이 분리되어도 되는데, 굳이 useEffect로 만들어야 할까요? useEffect가 너무 많아 로직이 복잡해보여서요.
 🧐 handleChatStart 에 useEffect 로직을 넣었습니다. 잘한게 맞을까여.. 




### 오류 
---
1. 처음 화면이 렌더링 된이후에 message를 입력하면 새로 고침 이후에 메세지가 보이는 에러 
2. 예) 민희님과의 채팅 내역이 준석님 채팅 화면에서 잠깐 보이는 에러 